### PR TITLE
add description to asd file

### DIFF
--- a/gravatar.asd
+++ b/gravatar.asd
@@ -5,6 +5,7 @@
 
 (defsystem gravatar
   :author "Greg Pfeil <greg@technomadic.org>"
+  :description "Common Lisp bindings to the popular Gravatar service."
   :license "Apache 2.0"
   :version "0.0.1"
   :depends-on (md5 drakma puri cl-json babel)


### PR DESCRIPTION
A trivial pull request to add a description to the system definition file (as asked by Xach [1]) to enable strict metadata checking in quicklisp.

[1] https://www.reddit.com/r/lisp/comments/37bxu7/systems_in_red_dont_build_if_strict_checking_of/
